### PR TITLE
Use OccurenceOrder & ModuleConcat plugins in production only

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -169,7 +169,7 @@ module.exports = {
         NODE_ENV: 'development',
         BLOG_ENTRIES: BLOG_ENTRIES.join(',')
       }),
-      new webpack.optimize.OccurrenceOrderPlugin(true),
+      isProduction && new webpack.optimize.OccurrenceOrderPlugin(true),
       new webpack.optimize.CommonsChunkPlugin({
         minChunks: (module, count) => {
           const isMarkdown = /^.*\.md$/.test(module.resource);
@@ -188,7 +188,7 @@ module.exports = {
           'manifest'
         ]
       }),
-      new webpack.optimize.ModuleConcatenationPlugin(),
+      isProduction && new webpack.optimize.ModuleConcatenationPlugin(),
       !isProduction && new BundleAnalyzerPlugin({
         analyzerMode: 'server',
         analyzerPort: 8088,


### PR DESCRIPTION
_should_ fix recent dev memory leaks (or at the very least speed things up)